### PR TITLE
fix: increase API timeout from 10 to 30 seconds

### DIFF
--- a/shipstation_integration/shipstation_integration/doctype/shipstation_settings/shipstation_settings.py
+++ b/shipstation_integration/shipstation_integration/doctype/shipstation_settings/shipstation_settings.py
@@ -30,7 +30,7 @@ class ShipstationSettings(Document):
 			key=self.get_password('api_key'),
 			secret=self.get_password('api_secret'),
 			debug=False,
-			timeout=10
+			timeout=30
 		)
 
 	def validate_enabled_checks(self):


### PR DESCRIPTION
For some reason, Shipstation's API fails to respond after a certain number of requests. Increasing the timeout will allow the rate limit to reset, and requests to continue.