### PR TITLE
fix(item): create items without defaults on first pull

### DIFF
--- a/shipstation_integration/items.py
+++ b/shipstation_integration/items.py
@@ -1,54 +1,52 @@
 import frappe
 
 
-def create_item(product, settings=None, store=None):
-    """
-    Create or update a Shipstation item, and setup item defaults.
+def create_item(product, settings, store=None):
+	"""
+	Create or update a Shipstation item, and setup item defaults.
 
-    Args:
-        product (ShipStationItem): The Shipstation item.
-        settings (ShipstationSettings, optional): The active Shipstation instance.
-            Defaults to None.
-        store (ShipstationStore, optional): The selected Shipstation store.
-            Defaults to None.
+	Args:
+		product (shipstation.ShipStationItem): The Shipstation item.
+		settings (ShipstationSettings, optional): The active Shipstation instance.
+		store (ShipstationStore, optional): The selected Shipstation store.
+			Defaults to None.
 
-    Returns:
-        str: The item code of the created or updated Shipstation item.
-    """
+	Returns:
+		str: The item code of the created or updated Shipstation item.
+	"""
 
-    if not product.sku:
-        item_name = product.name[:140]
-        item_code = frappe.get_value("Item", {"item_name": item_name.strip()})
-    else:
-        item_code = frappe.get_value(
-            "Item", {"item_code": product.sku.strip()})
+	if not product.sku:
+		item_name = product.name[:140]
+		item_code = frappe.get_value("Item", {"item_name": item_name.strip()})
+	else:
+		item_code = frappe.get_value("Item", {"item_code": product.sku.strip()})
 
-    if item_code:
-        item = frappe.get_doc("Item", item_code)
-    else:
-        item = frappe.new_doc("Item")
-        item.update({
-            "item_code": product.sku or product.name[:140],
-            "item_name": product.name[:140],
-            "item_group": settings.default_item_group,
-            "is_stock_item": 1,
-            "include_item_in_manufacturing": 0,
-            "description": getattr(product, "internal_notes", product.name),
-            "weight_per_unit": getattr(product, "weight_oz", 0),
-            "weight_uom": "Ounce",
-            "end_of_life": ""
-        })
+	if item_code:
+		item = frappe.get_doc("Item", item_code)
+	else:
+		item = frappe.new_doc("Item")
+		item.update({
+			"item_code": product.sku or product.name[:140],
+			"item_name": product.name[:140],
+			"item_group": settings.default_item_group,
+			"is_stock_item": 1,
+			"include_item_in_manufacturing": 0,
+			"description": getattr(product, "internal_notes", product.name),
+			"weight_per_unit": getattr(product, "weight_oz", 0),
+			"weight_uom": "Ounce",
+			"end_of_life": ""
+		})
 
-    if store and store.company and not item.item_defaults:
-        item.set("item_defaults", [{
-            "company": store.company,
-            "default_price_list": "ShipStation",
-            "default_warehouse": "",  # leave unset
-            "buying_cost_center": store.cost_center,
-            "selling_cost_center": store.cost_center,
-            "expense_account": store.expense_account,
-            "income_account": store.sales_account
-        }])
+	if store and store.company and not item.item_defaults:
+		item.set("item_defaults", [{
+			"company": store.company,
+			"default_price_list": "ShipStation",
+			"default_warehouse": "",  # leave unset
+			"buying_cost_center": store.cost_center,
+			"selling_cost_center": store.cost_center,
+			"expense_account": store.expense_account,
+			"income_account": store.sales_account
+		}])
 
-    item.save()
-    return item.item_code
+	item.save()
+	return item.item_code

--- a/shipstation_integration/orders.py
+++ b/shipstation_integration/orders.py
@@ -73,12 +73,12 @@ def create_erpnext_order(order, store):
 		if update_hook:
 			so = frappe.get_attr(update_hook[0])(store, order, so)
 
-	for row in getattr(order, 'items', []):
-		item_code = create_item(row, store)
-		rate = getattr(row, "unit_price", 0.0)
+	for item in getattr(order, 'items', []):
+		item_code = create_item(item, settings=store.parent_doc, store=store)
+		rate = getattr(item, "unit_price", 0.0)
 		so.append('items', {
 			'item_code': item_code,
-			'qty': row.quantity,
+			'qty': item.quantity,
 			'uom': 'Nos',
 			'conversion_factor': 1,
 			'rate': rate,

--- a/shipstation_integration/shipstation_integration/doctype/shipstation_settings/shipstation_settings.py
+++ b/shipstation_integration/shipstation_integration/doctype/shipstation_settings/shipstation_settings.py
@@ -24,6 +24,20 @@ class ShipstationSettings(Document):
 	def get_shipments():
 		list_shipments()
 
+	@property
+	def store_ids(self):
+		stores = json.loads(self.store_data)
+		stores = [json.loads(s) for s in stores]
+		return [s.get('storeId') for s in stores]
+
+	@property
+	def shipstation_methods(self):
+		return [t.strip() for t in self.trigger_on.split(",")]
+
+	def onload(self):
+		if self.carrier_data:
+			self.set_onload('carriers', self._carrier_data())
+
 	def validate(self):
 		if not self.api_key and not self.api_secret:
 			frappe.throw(_("API Key and Secret are both required."))
@@ -112,17 +126,3 @@ class ShipstationSettings(Document):
 					if pack['name'] == package:
 						_package = pack['code']
 		return _carrier, _service, _package
-
-	@property
-	def shipstation_methods(self):
-		return [t.strip() for t in self.trigger_on.split(",")]
-
-	def onload(self):
-		if self.carrier_data:
-			self.set_onload('carriers', self._carrier_data())
-
-	@property
-	def store_ids(self):
-		stores = json.loads(self.store_data)
-		stores = [json.loads(s) for s in stores]
-		return [s['storeId'] for s in stores]

--- a/shipstation_integration/shipstation_integration/doctype/shipstation_settings/shipstation_settings.py
+++ b/shipstation_integration/shipstation_integration/doctype/shipstation_settings/shipstation_settings.py
@@ -16,9 +16,17 @@ from shipstation_integration.utils import get_marketplace
 
 
 class ShipstationSettings(Document):
+	@staticmethod
+	def get_orders():
+		list_orders()
+
+	@staticmethod
+	def get_shipments():
+		list_shipments()
+
 	def validate(self):
 		if not self.api_key and not self.api_secret:
-			frappe.throw(frappe._("API Key and Secret are both required."))
+			frappe.throw(_("API Key and Secret are both required."))
 
 		self.validate_enabled_checks()
 
@@ -76,12 +84,6 @@ class ShipstationSettings(Document):
 				})
 		return self
 
-	def get_orders(self):
-		list_orders()
-
-	def get_shipments(self):
-		list_shipments()
-
 	def get_items(self):
 		products = self.client().list_products()
 		if not products.results:
@@ -101,7 +103,7 @@ class ShipstationSettings(Document):
 	def get_codes(self, carrier, service, package):
 		_carrier, _service, _package = None, None, 'Package'
 		for ss_carrier in self._carrier_data():
-			if ss_carrier['name'] == carrier or ss_carrier['nickname'] == carrier:
+			if carrier in [ss_carrier.get('name'), ss_carrier.get('nickname')]:
 				_carrier = ss_carrier['code']
 				for serv in ss_carrier['services']:
 					if serv['name'] == service:

--- a/shipstation_integration/shipstation_integration/doctype/shipstation_settings/shipstation_settings.py
+++ b/shipstation_integration/shipstation_integration/doctype/shipstation_settings/shipstation_settings.py
@@ -87,7 +87,7 @@ class ShipstationSettings(Document):
 		if not products.results:
 			return "No products found to import"
 		for product in products:
-			create_item(product)
+			create_item(product, settings=self)
 		return "{} product(s) imported succesfully".format(len(products.results))
 
 	def _carrier_data(self):


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "/home/rohan/parsimony/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/rohan/parsimony/apps/frappe/frappe/api.py", line 59, in handle
    return frappe.handler.handle()
  File "/home/rohan/parsimony/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/rohan/parsimony/apps/frappe/frappe/handler.py", line 64, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/rohan/parsimony/apps/frappe/frappe/__init__.py", line 1064, in call
    return fn(*args, **newargs)
  File "/home/rohan/parsimony/apps/frappe/frappe/handler.py", line 98, in runserverobj
    frappe.desk.form.run_method.runserverobj(method, docs=docs, dt=dt, dn=dn, arg=arg, args=args)
  File "/home/rohan/parsimony/apps/frappe/frappe/desk/form/run_method.py", line 43, in runserverobj
    r = doc.run_method(method)
  File "/home/rohan/parsimony/apps/frappe/frappe/model/document.py", line 797, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/rohan/parsimony/apps/frappe/frappe/model/document.py", line 1073, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/rohan/parsimony/apps/frappe/frappe/model/document.py", line 1056, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/rohan/parsimony/apps/frappe/frappe/model/document.py", line 791, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/rohan/parsimony/apps/shipstation_integration/shipstation_integration/shipstation_integration/doctype/shipstation_settings/shipstation_settings.py", line 90, in get_items
    create_item(product)
TypeError: create_item() missing 1 required positional argument: 'store'
```