### PR TITLE
fix: remove whitespace from customer before saving

### DIFF
--- a/shipstation_integration/customer.py
+++ b/shipstation_integration/customer.py
@@ -142,13 +142,12 @@ def create_customer(order: "ShipStationOrder"):
 
     customer_name = (
         order.customer_email or order.customer_id or order.ship_to.name or customer_id
-    )
+    ).strip()
 
     if frappe.db.exists("Customer", customer_name):
         return frappe.get_doc("Customer", customer_name)
 
     cust = frappe.new_doc("Customer")
-    cust.shipstation_customer_id = customer_id
     cust.customer_name = customer_name
     cust.customer_type = "Individual"
     cust.customer_group = "ShipStation"


### PR DESCRIPTION
A string like `' First Last'` would create the following traceback if `'First Last'` already exists:

```python
  File "frappe/utils/background_jobs.py", line 144, in execute_job
    method(**kwargs)
  File "shipstation_integration/orders.py", line 104, in list_orders
    create_erpnext_order(order, store)
  File "shipstation_integration/orders.py", line 170, in create_erpnext_order
    customer = create_customer(order)
  File "shipstation_integration/customer.py", line 156, in create_customer
    cust.save()
  File "frappe/model/document.py", line 312, in save
    return self._save(*args, **kwargs)
  File "frappe/model/document.py", line 334, in _save
    return self.insert()
  File "frappe/model/document.py", line 278, in insert
    raise e
  File "frappe/model/document.py", line 275, in insert
    self.db_insert()
  File "frappe/model/base_document.py", line 436, in db_insert
    raise frappe.DuplicateEntryError(self.doctype, self.name, e)
```